### PR TITLE
Fix syntax issues

### DIFF
--- a/github-overlay-scrollbars.user.css
+++ b/github-overlay-scrollbars.user.css
@@ -4,7 +4,7 @@
 @description GitHub overlay scrollbars
 @namespace   StylishThemes
 @author      StylishThemes
-+co-authors  https://github.com/StylishThemes/Overlay-Scrollbars/graphs/contributors
+@co-authors  https://github.com/StylishThemes/Overlay-Scrollbars/graphs/contributors
 @homepageURL https://github.com/StylishThemes/Overlay-Scrollbars
 @supportURL  https://github.com/StylishThemes/Overlay-Scrollbars/issues
 @updateURL   https://raw.githubusercontent.com/StylishThemes/Overlay-Scrollbars/master/github-overlay-scrollbars.user.css
@@ -30,7 +30,7 @@
     --custom-track-color: /*[[custom-track-color]]*/;
     --custom-thumb-color: /*[[custom-thumb-color]]*/;
     --custom-width: /*[[custom-width]]*/;
-    --webkit-scrollbar-thumb-hover: /*[[custom-thumb-color-hover]]*/);
+    --webkit-scrollbar-thumb-hover: /*[[custom-thumb-color-hover]]*/;
     --webkit-scrollbar-track-hover: /*[[custom-track-color-hover]]*/;
     --webkit-scrollbar-width-height: /*[[webkit-scrollbar-width-height]]*/;
     --webkit-scrollbar-border-radius: /*[[webkit-scrollbar-border-radius]]*/;

--- a/global-overlay-scrollbars.user.css
+++ b/global-overlay-scrollbars.user.css
@@ -4,7 +4,7 @@
 @description Global overlay scrollbars
 @namespace   StylishThemes
 @author      StylishThemes
-+co-authors  https://github.com/StylishThemes/Overlay-Scrollbars/graphs/contributors
+@co-authors  https://github.com/StylishThemes/Overlay-Scrollbars/graphs/contributors
 @homepageURL https://github.com/StylishThemes/Overlay-Scrollbars
 @supportURL  https://github.com/StylishThemes/Overlay-Scrollbars/issues
 @updateURL   https://raw.githubusercontent.com/StylishThemes/Overlay-Scrollbars/master/global-overlay-scrollbars.user.css


### PR DESCRIPTION
Hi,

This fixes the issue reported in https://github.com/openstyles/stylus/issues/891.

I wasn't sure if `+co-authors` was intended to be like that, so I replaced it with `@co-authors`. Let me know if that causes issues with extensions other than Stylus and I'll quickly fix it.